### PR TITLE
Fix charm build error.

### DIFF
--- a/charm/ksql/metadata.yaml
+++ b/charm/ksql/metadata.yaml
@@ -1,5 +1,5 @@
 name: ksql
-summary: Streaming SQL engine that enables real-time data processing against Apache Kafka.
+summary: SQL interface for stream processing on Kafka
 maintainer: Khanh Nguyen <khanh.nguyen@canonical.com>
 description: |
   Provides an easy-to-use, yet powerful interactive SQL interface for stream processing on Kafka, without the need to write code in a programming language such as Java or Python. 


### PR DESCRIPTION
The charm tool aggressively limits the length of the summary field:

```
make[1]: Entering directory
'/home/c/Projects/ksql-snap-charm/charm/ksql'
charm build -o ..
build: Please add a `repo` key to your layer.yaml, with a url from which
your layer can be cloned.
build: Destination charm directory:
/home/c/Projects/ksql-snap-charm/charm/builds/ksql
build: Processing layer: layer:options
build: Processing layer: layer:basic
build: Processing layer: layer:debug
build: Processing layer: layer:tls-client
build: Processing layer: ksql (from .)
build: Processing interface: kafka
build: Processing interface: http
build: Processing interface: tls-certificates
proof: W: summary should be less than 72
proof: I: `display-name` not provided, add for custom naming in the UI
Makefile:2: recipe for target 'all' failed
```

This shortens the description enough that it will STFU and exit 0.