### PR TITLE
Remove xenial series from charm.

### DIFF
--- a/charm/ksql/metadata.yaml
+++ b/charm/ksql/metadata.yaml
@@ -8,7 +8,6 @@ tags:
   - streaming
 min-juju-version: "2.4.0"
 series:
-  - xenial
   - bionic
 subordinate: false
 requires:


### PR DESCRIPTION
xenial could be supported, but we'll standardize on bionic unless there
is some reason to deploy onto xenial.